### PR TITLE
Add Automated Remediation for 5.5.1.1

### DIFF
--- a/defaults/main/section_02.yml
+++ b/defaults/main/section_02.yml
@@ -66,7 +66,7 @@ ubuntu_2004_cis_section2_rule_2_1_3_params_package_purge: yes
 # Variables for 2.1.4
 ubuntu_2004_cis_section2_rule_2_1_4: true
 
-ubuntu_2004_cis_section2_rule_2_1_4_params_package_name: 
+ubuntu_2004_cis_section2_rule_2_1_4_params_package_name:
   - cups
   - cups-common
   - cups-server-common
@@ -105,7 +105,7 @@ ubuntu_2004_cis_section2_rule_2_1_8_params_package_purge: yes
 # Variables for 2.1.9
 ubuntu_2004_cis_section2_rule_2_1_9: true
 
-ubuntu_2004_cis_section2_rule_2_1_9_params_package_name: 
+ubuntu_2004_cis_section2_rule_2_1_9_params_package_name:
   - vsftpd
   - proftpd-basic
 ubuntu_2004_cis_section2_rule_2_1_9_params_package_state: absent
@@ -114,7 +114,7 @@ ubuntu_2004_cis_section2_rule_2_1_9_params_package_purge: yes
 # Variables for 2.1.10
 ubuntu_2004_cis_section2_rule_2_1_10: true
 
-ubuntu_2004_cis_section2_rule_2_1_10_params_package_name: 
+ubuntu_2004_cis_section2_rule_2_1_10_params_package_name:
   - apache
   - apache2
   - lighttpd

--- a/tasks/section_05.yml
+++ b/tasks/section_05.yml
@@ -820,14 +820,39 @@
     - level_1
 
 - name: "5.5.1.1| Ensure minimum days between password changes is configured (Automated)"
-  lineinfile:
-    path: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_path }}"
-    line: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_line }}"
-    regexp: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_regexp }}"
-    state: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_state }}"
-    owner: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_owner }}"
-    group: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_group }}"
-    mode: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_mode }}"
+  block:
+    - name: "5.5.1.1| Ensure minimum days between password changes is configured (Automated)"
+      lineinfile:
+        path: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_path }}"
+        line: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_line }}"
+        regexp: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_regexp }}"
+        state: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_state }}"
+        owner: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_owner }}"
+        group: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_group }}"
+        mode: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_mode }}"
+    - name: "5.5.1.1| Get list of all users (Automated)"
+      get_ent:
+        database: shadow
+        split: ':'
+    - name: "5.5.1.1| Identify users requiring remediation of minimum days between password changes. (Automated)"
+      set_fact:
+        ubuntu_2004_cis_5_5_1_1_remediated_users: >-
+          {%- set items = [] -%}
+          {%- for key in ansible_facts.getent_shadow -%}
+          {%- if ansible_facts.getent_shadow[key][0] != '!*' 
+              and ansible_facts.getent_shadow[key][0] != '*'
+              and ansible_facts.getent_shadow[key][0] != '!'
+              and ansible_facts.getent_shadow[key][0] != '!!'
+              and ansible_facts.getent_shadow[key][2] | int < ubuntu_2004_cis_require_passmindays -%}
+          {{ items.append(key) }}
+          {%- endif -%}
+          {%- endfor -%}
+          {{ items | to_json }}
+    - name: "5.5.1.1| Remediate users with password min days less than {{ubuntu_2004_cis_require_passmindays}}. (Automated)"
+      user:
+        name: "{{ item }}"
+        password_expire_min: "{{ ubuntu_2004_cis_require_passmindays }}"
+      loop: "{{ ubuntu_2004_cis_5_5_1_1_remediated_users }}"
   when:
     - ubuntu_2004_cis_section5_rule_5_5_1_1
     - ubuntu_2004_cis_section5

--- a/tasks/section_05.yml
+++ b/tasks/section_05.yml
@@ -839,7 +839,7 @@
         ubuntu_2004_cis_5_5_1_1_remediated_users: >-
           {%- set items = [] -%}
           {%- for key in ansible_facts.getent_shadow -%}
-          {%- if ansible_facts.getent_shadow[key][0] != '!*' 
+          {%- if ansible_facts.getent_shadow[key][0] != '!*'
               and ansible_facts.getent_shadow[key][0] != '*'
               and ansible_facts.getent_shadow[key][0] != '!'
               and ansible_facts.getent_shadow[key][0] != '!!'


### PR DESCRIPTION
- Adds logic to inspect /etc/shadow for users with a password whose
  password min days is less than the specified number.