### PR TITLE
fix incorrectly spelled module

### DIFF
--- a/tasks/section_05.yml
+++ b/tasks/section_05.yml
@@ -831,7 +831,7 @@
         group: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_group }}"
         mode: "{{ ubuntu_2004_cis_section5_rule_5_5_1_1_params_mode }}"
     - name: "5.5.1.1| Get list of all users (Automated)"
-      get_ent:
+      getent:
         database: shadow
         split: ':'
     - name: "5.5.1.1| Identify users requiring remediation of minimum days between password changes. (Automated)"


### PR DESCRIPTION
`get_ent` is not a valid module name.